### PR TITLE
test: handle low file descriptor limits

### DIFF
--- a/helper_stub_test.go
+++ b/helper_stub_test.go
@@ -1,0 +1,12 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!windows
+
+package overflow
+
+func maxOpenFiles() int {
+	return defaultMaxOpenFiles
+}

--- a/helper_unix_test.go
+++ b/helper_unix_test.go
@@ -1,0 +1,18 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package overflow
+
+import "syscall"
+
+func maxOpenFiles() int {
+	var rlim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
+		return defaultMaxOpenFiles
+	}
+	return int(rlim.Cur)
+}

--- a/helper_windows_test.go
+++ b/helper_windows_test.go
@@ -1,0 +1,9 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package overflow
+
+func maxOpenFiles() int {
+	return 4 * defaultMaxOpenFiles /* actually it's 16581375 */
+}


### PR DESCRIPTION
This restores previously-deleted helper_*_test.go as they were before
9d1f38670e7e90725eeb2c02107efcb85eb08c34.

Signed-off-by: Erik Swanson <erik@retailnext.net>